### PR TITLE
avoid sed fails when find returns empty result

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ runs:
   steps:
     - run: |
         find ${{ inputs.directory}} -name "*.map" -delete
-        find ${{ inputs.directory}} -name "*.js" | xargs sed -i -e '/\/\/# sourceMappingURL.*/d'
-        find ${{ inputs.directory}} -name "*.css" | xargs sed -i -e '/\/\*# sourceMappingURL.*/d'
+        find ${{ inputs.directory}} -name "*.js" | xargs --no-run-if-empty sed -i -e '/\/\/# sourceMappingURL.*/d'
+        find ${{ inputs.directory}} -name "*.css" | xargs --no-run-if-empty sed -i -e '/\/\*# sourceMappingURL.*/d'
       shell: bash


### PR DESCRIPTION
Fix `sed: no input files` error